### PR TITLE
Allow setting of test device ids on android

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,8 @@ const { AdMob } = Plugins;
 export class AppComponent {
   constructor() {
     // Initialize AdMob for your Application
-    AdMob.initialize("YOUR APPID");
+    // For Android you can optionally pass in a list of test device ids
+    AdMob.initialize("YOUR APPID", ['OPTIONAL TEST IDS']);
   }
 }
 ```

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -43,7 +43,7 @@ dependencies {
     testImplementation 'junit:junit:4.12'
     androidTestImplementation 'com.android.support.test:runner:1.0.2'
     androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'
-    implementation 'com.google.android.gms:play-services-ads:17.2.0'
+    implementation 'com.google.android.gms:play-services-ads:18.3.0'
     implementation 'com.android.support:appcompat-v7:27.1.1'
 }
 

--- a/android/src/main/java/app/xplatform/capacitor/plugins/AdMob.java
+++ b/android/src/main/java/app/xplatform/capacitor/plugins/AdMob.java
@@ -19,9 +19,13 @@ import com.google.android.gms.ads.AdSize;
 import com.google.android.gms.ads.AdView;
 import com.google.android.gms.ads.InterstitialAd;
 import com.google.android.gms.ads.MobileAds;
+import com.google.android.gms.ads.RequestConfiguration;
 import com.google.android.gms.ads.reward.RewardItem;
 import com.google.android.gms.ads.reward.RewardedVideoAd;
 import com.google.android.gms.ads.reward.RewardedVideoAdListener;
+
+import java.util.ArrayList;
+import java.util.List;
 
 
 @NativePlugin(
@@ -59,6 +63,20 @@ public class AdMob extends Plugin {
 
         try {
             MobileAds.initialize(this.getContext(), appId);
+
+            List<String> testIds = call.getArray("testIds").toList();
+
+            if (testIds.size() > 0) {
+                List<String> testDevices = new ArrayList<>();
+                testDevices.add(AdRequest.DEVICE_ID_EMULATOR);
+
+                RequestConfiguration requestConfiguration
+                        = new RequestConfiguration.Builder()
+                        .setTestDeviceIds(testDevices)
+                        .build();
+                MobileAds.setRequestConfiguration(requestConfiguration);
+            }
+
 
             mViewGroup = (ViewGroup) ((ViewGroup) getActivity().findViewById(android.R.id.content)).getChildAt(0);
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,29 +5,29 @@
   "requires": true,
   "dependencies": {
     "@capacitor/android": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@capacitor/android/-/android-1.3.0.tgz",
-      "integrity": "sha512-b+x15Sr4hOHUe45CaS2Xh6yc0zTjamo3eF0Wpra/rsh6gOwoI4bBRqwvKLeWsQRK1zakClfoFUSgpRWCAPASGw==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@capacitor/android/-/android-1.5.1.tgz",
+      "integrity": "sha512-dubGu+Im5uqdkLBX9c0azGF1v3AY1HTlWxZmjn7qN48AXJL3woxCi4TVv2MEXJRxgfQq5Aunqu6rsmF/bDaOHw==",
       "dev": true
     },
     "@capacitor/core": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@capacitor/core/-/core-1.3.0.tgz",
-      "integrity": "sha512-cVllg+OaYAPCsWOOOuMDqIk0tqjTH1QEBNgTKhAwLJraYy0w5CziUW5gtcmKXTRqD3dzUlHjx1emCKXrg0DACg==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@capacitor/core/-/core-1.5.1.tgz",
+      "integrity": "sha512-3ncsiM+G1w4/osKbtPXGfHGOp/A1WKein1EVDX3O151aqjNf44F+n/zweZG1XvtOmY4AHNaQcHYO/s9nMOmPOw==",
       "requires": {
         "tslib": "^1.9.0"
       }
     },
     "@capacitor/ios": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@capacitor/ios/-/ios-1.3.0.tgz",
-      "integrity": "sha512-iRFM1uMvlFS/N/6GJ735uE4OzjyrxDNPb8+OBUyRqmL7j/XBSv1mjKG5gpk2zWIbj/sXWWBHwXleuBsDIG7Fpg==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@capacitor/ios/-/ios-1.5.1.tgz",
+      "integrity": "sha512-6b8o/U87KIRWj3OLT+RrStTS56FWF7/dJkFe75XS5PBZPlWl8dKB3MUb3oKpWX5E7Y105Yo8CA/fKOSk8QQzsg==",
       "dev": true
     },
     "tslib": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
-      "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ=="
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.1.tgz",
+      "integrity": "sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA=="
     },
     "typescript": {
       "version": "3.7.3",

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -8,8 +8,8 @@ declare global {
 
 export interface AdMobPlugin {
 
-  // Initialize AdMob with appId
-  initialize(options: { appId: string }): Promise<{ value: boolean }>
+  // Initialize AdMob with appId and optional test device IDs
+  initialize(options: { appId: string, testIds?: string[] }): Promise<{ value: boolean }>
 
   // Show a banner Ad
   showBanner(options: AdOptions): Promise<{ value: boolean }>;


### PR DESCRIPTION
I did not find a way to test this locally so I couldn't do it.

If you have any way to test a plugin without publishing please let me know and I'll do it.